### PR TITLE
add on conflict clause

### DIFF
--- a/syngenta_digital_dta/postgres/json_formatting.py
+++ b/syngenta_digital_dta/postgres/json_formatting.py
@@ -4,6 +4,8 @@ def insert_json_into_table(
         column_map,
         json_column_map,
         function_map=None,
+        conflict_cols=None,
+        update_cols=None
 ):
     [target_key] = {v.split(".")[0] for v in json_column_map.values()}
 
@@ -11,7 +13,7 @@ def insert_json_into_table(
         f"""{_build_json_cte(json)}
         {_build_insert_statement(table_name, column_map, json_column_map)}
         {_build_select_statement(column_map, json_column_map, function_map or {})}
-        FROM ({_build_json_array_subquery(target_key)})x
+        FROM ({_build_json_array_subquery(target_key)})x {_build_on_conflict(conflict_cols, update_cols)}
 """
     )
 
@@ -22,6 +24,17 @@ def _build_json_cte(json):
 
 def _build_insert_statement(table, column_map, json_column_map):
     return f"INSERT INTO {table} ({', '.join(_get_column_order(column_map, json_column_map))})"
+
+
+def _build_on_conflict(conflict_cols, update_cols):
+    if conflict_cols and update_cols:
+        sql = f"ON CONFLICT ({', '.join(conflict_cols)}) "
+        update = f"DO UPDATE SET ({','.join(update_cols)}) = ({','.join(map(lambda x: 'excluded.' + x, update_cols))})"
+        return sql + update
+    elif conflict_cols:
+        return "ON CONFLICT DO NOTHING"
+    else:
+        return ''
 
 
 def _build_json_array_subquery(target_key):

--- a/syngenta_digital_dta/postgres/json_formatting.py
+++ b/syngenta_digital_dta/postgres/json_formatting.py
@@ -30,11 +30,13 @@ def _build_on_conflict(conflict_cols, update_cols):
     if conflict_cols and update_cols:
         sql = f"ON CONFLICT ({', '.join(conflict_cols)}) "
         update = f"DO UPDATE SET ({','.join(update_cols)}) = ({','.join(map(lambda x: 'excluded.' + x, update_cols))})"
-        return sql + update
+        sql = sql + update
     elif conflict_cols:
-        return "ON CONFLICT DO NOTHING"
+        sql = "ON CONFLICT DO NOTHING"
     else:
-        return ''
+        sql = ''
+
+    return sql
 
 
 def _build_json_array_subquery(target_key):

--- a/tests/syngenta_digital_dta/postgres/test_json_formatting.py
+++ b/tests/syngenta_digital_dta/postgres/test_json_formatting.py
@@ -129,7 +129,7 @@ class TestJsonFormatting(unittest.TestCase):
         expected = """WITH _json_cte AS (SELECT '{}'::json AS _json)
         INSERT INTO my_table (guuid, created_at, updated_at, time, machine, secID)
         SELECT generate_uuid_v4() AS guuid, now() AS created_at, now() AS updated_at, _jsondict -> 'properties' ->> 'Time' AS time, _jsondict -> 'properties' ->> 'Machine' AS machine, _jsondict -> 'properties' ->> 'SecID' AS secID
-        FROM (SELECT json_array_elements(_json->'feature') AS _jsondict FROM _json_cte)x
+        FROM (SELECT json_array_elements(_json->'feature') AS _jsondict FROM _json_cte)x 
 """
 
         self.assertEqual(expected, actual)
@@ -164,7 +164,37 @@ class TestJsonFormatting(unittest.TestCase):
         expected = """WITH _json_cte AS (SELECT '{}'::json AS _json)
         INSERT INTO my_table (guuid, created_at, updated_at, time, machine, secID)
         SELECT generate_uuid_v4() AS guuid, now() AS created_at, now() AS updated_at, _jsondict -> 'properties' ->> 'Time' AS time, _jsondict -> 'properties' ->> 'Machine' AS machine, cast(_jsondict -> 'properties' ->> 'SecID' as varchar) as secID
-        FROM (SELECT json_array_elements(_json->'feature') AS _jsondict FROM _json_cte)x
+        FROM (SELECT json_array_elements(_json->'feature') AS _jsondict FROM _json_cte)x 
 """
+
+        self.assertEqual(expected, actual)
+
+    def test_on_conflict_clause_do_update(self):
+        actual = json_formatting._build_on_conflict(
+            conflict_cols=('a', 'b', 'c'),
+            update_cols=('b', 'c')
+        )
+
+        expected = 'ON CONFLICT (a, b, c) DO UPDATE SET (b,c) = (excluded.b,excluded.c)'
+
+        self.assertEqual(expected, actual)
+
+    def test_on_conflict_clause_do_nothing(self):
+        actual = json_formatting._build_on_conflict(
+            conflict_cols=('a', 'b', 'c'),
+            update_cols=None
+        )
+
+        expected = 'ON CONFLICT DO NOTHING'
+
+        self.assertEqual(expected, actual)
+
+    def test_on_conflict_clause_none(self):
+        actual = json_formatting._build_on_conflict(
+            conflict_cols=None,
+            update_cols=None
+        )
+
+        expected = ''
 
         self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR adds the ability to specificy how postgres behaves when facing unique constraint collisions, the options being update the provided columns, ignore the offending rows, and nothing i.e. fail.